### PR TITLE
대시보드 뉴모피즘 디자인 흰색 배경 적용

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1111,9 +1111,9 @@ export default function DashboardPage() {
                       }`}
                     >
                       <div className="flex items-center space-x-3">
-                        <div className="w-4 h-4 bg-gray-200 rounded border" style={{
-                          background: 'linear-gradient(145deg, #f0f0f3, #cacace)',
-                          boxShadow: '2px 2px 4px #a8a8aa, -2px -2px 4px #ffffff'
+                        <div className="w-4 h-4 bg-white rounded border" style={{
+                          background: '#ffffff',
+                          boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.1), -2px -2px 4px rgba(255, 255, 255, 0.8)'
                         }}></div>
                         <div>
                           <h4 className="font-semibold text-gray-900">뉴모피즘</h4>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,42 +69,42 @@ body {
 
 /* 뉴모피즘 디자인 스타일 */
 .neumorphism-card {
-  background: linear-gradient(145deg, #f0f0f3, #cacace);
-  box-shadow: 9px 9px 16px #a8a8aa, -9px -9px 16px #ffffff;
+  background: #ffffff;
+  box-shadow: 8px 8px 16px rgba(0, 0, 0, 0.1), -8px -8px 16px rgba(255, 255, 255, 0.8);
   border: none;
 }
 
 .neumorphism-card-inset {
-  background: linear-gradient(145deg, #cacace, #f0f0f3);
-  box-shadow: inset 6px 6px 12px #a8a8aa, inset -6px -6px 12px #ffffff;
+  background: #ffffff;
+  box-shadow: inset 6px 6px 12px rgba(0, 0, 0, 0.08), inset -6px -6px 12px rgba(255, 255, 255, 0.9);
 }
 
 .neumorphism-button {
-  background: linear-gradient(145deg, #f0f0f3, #cacace);
-  box-shadow: 4px 4px 8px #a8a8aa, -4px -4px 8px #ffffff;
+  background: #ffffff;
+  box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.1), -4px -4px 8px rgba(255, 255, 255, 0.8);
   border: none;
   transition: all 0.2s ease;
 }
 
 .neumorphism-button:hover {
-  background: linear-gradient(145deg, #e8e8eb, #c2c2c6);
-  box-shadow: 2px 2px 4px #a8a8aa, -2px -2px 4px #ffffff;
+  background: #ffffff;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.12), -2px -2px 4px rgba(255, 255, 255, 0.9);
 }
 
 .neumorphism-button:active {
-  background: linear-gradient(145deg, #cacace, #f0f0f3);
-  box-shadow: inset 2px 2px 4px #a8a8aa, inset -2px -2px 4px #ffffff;
+  background: #ffffff;
+  box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.08), inset -2px -2px 4px rgba(255, 255, 255, 0.9);
 }
 
 .neumorphism-input {
-  background: linear-gradient(145deg, #cacace, #f0f0f3);
-  box-shadow: inset 3px 3px 6px #a8a8aa, inset -3px -3px 6px #ffffff;
+  background: #ffffff;
+  box-shadow: inset 3px 3px 6px rgba(0, 0, 0, 0.08), inset -3px -3px 6px rgba(255, 255, 255, 0.9);
   border: none;
 }
 
 .neumorphism-progress {
-  background: linear-gradient(145deg, #cacace, #f0f0f3);
-  box-shadow: inset 2px 2px 4px #a8a8aa, inset -2px -2px 4px #ffffff;
+  background: #ffffff;
+  box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.08), inset -2px -2px 4px rgba(255, 255, 255, 0.9);
 }
 
 .neumorphism-progress-fill {
@@ -114,8 +114,43 @@ body {
 
 /* 뉴모피즘 배경 */
 .neumorphism-bg {
-  background: #e0e5ec;
+  background: #f5f5f5;
   background-image: 
-    radial-gradient(circle at 25% 25%, #ffffff 0%, transparent 50%),
-    radial-gradient(circle at 75% 75%, #d1d9e6 0%, transparent 50%);
+    radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.8) 0%, transparent 50%),
+    radial-gradient(circle at 75% 75%, rgba(0, 0, 0, 0.02) 0%, transparent 50%);
+}
+
+/* 뉴모피즘 모달 전용 스타일 */
+.neumorphism-modal {
+  background: #ffffff;
+  box-shadow: 
+    12px 12px 24px rgba(0, 0, 0, 0.1), 
+    -12px -12px 24px rgba(255, 255, 255, 0.9),
+    inset 1px 1px 2px rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* 뉴모피즘 모달 헤더 */
+.neumorphism-modal-header {
+  background: #ffffff;
+  box-shadow: 
+    0 2px 4px rgba(0, 0, 0, 0.05),
+    inset 0 1px 2px rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+/* 뉴모피즘 모달 버튼 */
+.neumorphism-modal-button {
+  background: #ffffff;
+  box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.08), -3px -3px 6px rgba(255, 255, 255, 0.8);
+  border: none;
+  transition: all 0.2s ease;
+}
+
+.neumorphism-modal-button:hover {
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1), -2px -2px 4px rgba(255, 255, 255, 0.9);
+}
+
+.neumorphism-modal-button:active {
+  box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.08), inset -1px -1px 2px rgba(255, 255, 255, 0.9);
 }

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -53,6 +53,8 @@ function SortableItem({
     isDragging,
   } = useSortable({ id: plan.id })
 
+  const { getCardStyle } = useTheme()
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -63,7 +65,7 @@ function SortableItem({
     <div 
       ref={setNodeRef} 
       style={style} 
-      className={`bg-white rounded-lg shadow-sm p-4 ${isDragging ? 'z-50' : ''}`}
+      className={`${getCardStyle()} ${isDragging ? 'z-50' : ''}`}
     >
       <div className="flex items-start justify-between">
         <div className="flex-1">
@@ -137,7 +139,7 @@ export default function PlansPage() {
   const [isSaving, setIsSaving] = useState(false)
   
   // 전역 테마 시스템 사용
-  const { getCardStyle, getCardStyleLarge, getButtonStyle, getBackgroundStyle, getInputStyle, getTabButtonStyle } = useTheme()
+  const { getCardStyle, getCardStyleLarge, getButtonStyle, getBackgroundStyle, getInputStyle, getTabButtonStyle, getModalStyle, getModalHeaderStyle, getModalButtonStyle, getModalBackdropStyle } = useTheme()
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -463,14 +465,14 @@ export default function PlansPage() {
         </DndContext>
 
         {isModalOpen && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-lg w-full max-w-md">
-              <div className="p-4 border-b border-gray-200">
+          <div className={getModalBackdropStyle()}>
+            <div className={`${getModalStyle()} w-full max-w-md`}>
+              <div className={getModalHeaderStyle()}>
                 <div className="flex items-center justify-between">
                   <h2 className="text-lg font-semibold">
                     {editingPlan ? '계획 편집' : '새 계획'}
                   </h2>
-                  <button onClick={closeModal} className="p-2 hover:bg-gray-100 rounded">
+                  <button onClick={closeModal} className={getModalButtonStyle()}>
                     <X className="h-4 w-4" />
                   </button>
                 </div>
@@ -485,7 +487,7 @@ export default function PlansPage() {
                     type="text"
                     value={formData.title}
                     onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={getInputStyle()}
                     placeholder="계획 제목을 입력하세요"
                   />
                 </div>
@@ -508,7 +510,7 @@ export default function PlansPage() {
                   <textarea
                     value={formData.description}
                     onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={getInputStyle()}
                     rows={aiSuggestion ? 8 : 3}
                     placeholder="계획에 대한 상세 설명을 입력하세요 (선택사항)"
                   />
@@ -553,7 +555,7 @@ export default function PlansPage() {
                     type="date"
                     value={formData.due_date}
                     onChange={(e) => setFormData({ ...formData, due_date: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={getInputStyle()}
                   />
                 </div>
 
@@ -564,7 +566,7 @@ export default function PlansPage() {
                   <select
                     value={formData.priority}
                     onChange={(e) => setFormData({ ...formData, priority: e.target.value as 'low' | 'medium' | 'high' })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={getInputStyle()}
                   >
                     <option value="low">낮음</option>
                     <option value="medium">보통</option>
@@ -573,33 +575,35 @@ export default function PlansPage() {
                 </div>
               </div>
 
-              <div className="p-4 border-t border-gray-200 flex space-x-2">
-                <button
-                  onClick={handleSavePlan}
-                  disabled={!formData.title || isSaving}
-                  className="flex-1 bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
-                >
-                  <Save className="h-4 w-4" />
-                  <span>{isSaving ? '저장 중...' : '저장'}</span>
-                </button>
-                {editingPlan && (
+              <div className={`${getModalHeaderStyle()} border-t`}>
+                <div className="flex space-x-2">
                   <button
-                    onClick={() => {
-                      handleDeletePlan(editingPlan.id)
-                      closeModal()
-                    }}
-                    className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 flex items-center space-x-2"
+                    onClick={handleSavePlan}
+                    disabled={!formData.title || isSaving}
+                    className="flex-1 bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
                   >
-                    <Trash2 className="h-4 w-4" />
-                    <span>삭제</span>
+                    <Save className="h-4 w-4" />
+                    <span>{isSaving ? '저장 중...' : '저장'}</span>
                   </button>
-                )}
-                <button
-                  onClick={closeModal}
-                  className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-                >
-                  취소
-                </button>
+                  {editingPlan && (
+                    <button
+                      onClick={() => {
+                        handleDeletePlan(editingPlan.id)
+                        closeModal()
+                      }}
+                      className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 flex items-center space-x-2"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span>삭제</span>
+                    </button>
+                  )}
+                  <button
+                    onClick={closeModal}
+                    className={`${getModalButtonStyle()} px-4 py-2 border border-gray-300`}
+                  >
+                    취소
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -125,7 +125,7 @@ export default function TemplatesPage() {
   })
   
   // 전역 테마 시스템 사용
-  const { getCardStyle, getCardStyleLarge, getButtonStyle, getBackgroundStyle, getInputStyle } = useTheme()
+  const { getCardStyle, getCardStyleLarge, getButtonStyle, getBackgroundStyle, getInputStyle, getModalStyle, getModalHeaderStyle, getModalButtonStyle, getModalBackdropStyle } = useTheme()
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -652,9 +652,9 @@ export default function TemplatesPage() {
         </div>
 
         {isModalOpen && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-xl w-full max-w-md max-h-[90vh] overflow-y-auto shadow-2xl">
-              <div className="p-4 border-b border-gray-200 bg-gradient-to-r from-blue-50 to-indigo-50">
+          <div className={getModalBackdropStyle()}>
+            <div className={`${getModalStyle()} w-full max-w-md max-h-[90vh] overflow-y-auto`}>
+              <div className={getModalHeaderStyle()}>
                 <div className="flex items-center justify-between">
                   <div>
                     <h2 className="text-lg font-semibold text-gray-900 flex items-center">
@@ -676,7 +676,7 @@ export default function TemplatesPage() {
                   </div>
                   <button 
                     onClick={closeModal} 
-                    className="p-2 hover:bg-white/50 rounded-lg transition-colors"
+                    className={getModalButtonStyle()}
                   >
                     <X className="h-4 w-4" />
                   </button>
@@ -693,7 +693,7 @@ export default function TemplatesPage() {
                       type="text"
                       value={formData.title}
                       onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                      className="w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+                      className={getInputStyle()}
                       placeholder="예: 일일 루틴, 주간 계획..."
                     />
                   </div>
@@ -705,7 +705,7 @@ export default function TemplatesPage() {
                     <textarea
                       value={formData.description}
                       onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                      className="w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors resize-none"
+                      className={`${getInputStyle()} resize-none`}
                       rows={3}
                       placeholder="템플릿에 대한 간단한 설명을 입력하세요"
                     />
@@ -789,9 +789,9 @@ export default function TemplatesPage() {
 
         {/* 템플릿 미리보기 모달 */}
         {previewTemplate && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-xl w-full max-w-md max-h-[90vh] overflow-y-auto shadow-2xl">
-              <div className="p-4 border-b border-gray-200 bg-gradient-to-r from-purple-50 to-blue-50">
+          <div className={getModalBackdropStyle()}>
+            <div className={`${getModalStyle()} w-full max-w-md max-h-[90vh] overflow-y-auto`}>
+              <div className={getModalHeaderStyle()}>
                 <div className="flex items-center justify-between">
                   <div>
                     <h2 className="text-lg font-semibold text-gray-900 flex items-center">
@@ -802,7 +802,7 @@ export default function TemplatesPage() {
                   </div>
                   <button 
                     onClick={() => setPreviewTemplate(null)} 
-                    className="p-2 hover:bg-white/50 rounded-lg transition-colors"
+                    className={getModalButtonStyle()}
                   >
                     <X className="h-4 w-4" />
                   </button>

--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -26,7 +26,7 @@ export default function TodosPage() {
   const [newTodoTitle, setNewTodoTitle] = useState('')
   
   // 전역 테마 시스템 사용
-  const { getCardStyle, getCardStyleLarge, getButtonStyle, getBackgroundStyle, getInputStyle } = useTheme()
+  const { getCardStyle, getCardStyleLarge, getButtonStyle, getBackgroundStyle, getInputStyle, getModalStyle, getModalHeaderStyle, getModalButtonStyle, getModalBackdropStyle } = useTheme()
 
   const fetchTodos = useCallback(async () => {
     const { data, error } = await supabase
@@ -448,9 +448,9 @@ export default function TodosPage() {
         </div>
 
         {isModalOpen && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-            <div className={getCardStyleLarge() + " w-full max-w-md"}>
-              <div className="p-4 border-b border-gray-200">
+          <div className={getModalBackdropStyle()}>
+            <div className={`${getModalStyle()} w-full max-w-md`}>
+              <div className={getModalHeaderStyle()}>
                 <h2 className="text-lg font-semibold">템플릿에서 추가</h2>
               </div>
               <div className="p-4">
@@ -458,10 +458,10 @@ export default function TodosPage() {
                   {templates.map((template) => (
                     <div
                       key={template.id}
-                      className={`p-3 border rounded-lg cursor-pointer ${
+                      className={`p-3 rounded-lg cursor-pointer ${
                         selectedTemplate === template.id
-                          ? 'border-blue-500 bg-blue-50'
-                          : 'border-gray-200 hover:border-gray-300'
+                          ? getButtonStyle() + ' border-blue-500 bg-blue-50'
+                          : getButtonStyle() + ' hover:opacity-80'
                       }`}
                       onClick={() => setSelectedTemplate(template.id)}
                     >
@@ -501,23 +501,25 @@ export default function TodosPage() {
                   ))}
                 </div>
               </div>
-              <div className="p-4 border-t border-gray-200 flex space-x-2">
-                <button
-                  onClick={handleAddFromTemplate}
-                  disabled={!selectedTemplate}
-                  className="flex-1 bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50"
-                >
-                  추가
-                </button>
-                <button
-                  onClick={() => {
-                    setIsModalOpen(false)
-                    setSelectedTemplate('')
-                  }}
-                  className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-                >
-                  취소
-                </button>
+              <div className={`${getModalHeaderStyle()} border-t`}>
+                <div className="flex space-x-2">
+                  <button
+                    onClick={handleAddFromTemplate}
+                    disabled={!selectedTemplate}
+                    className="flex-1 bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    추가
+                  </button>
+                  <button
+                    onClick={() => {
+                      setIsModalOpen(false)
+                      setSelectedTemplate('')
+                    }}
+                    className={`${getModalButtonStyle()} px-4 py-2 border border-gray-300`}
+                  >
+                    취소
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/lib/context/ThemeContext.tsx
+++ b/src/lib/context/ThemeContext.tsx
@@ -17,6 +17,10 @@ interface ThemeContextType {
   getInputStyle: () => string
   getTextColor: () => string
   getSubtextColor: () => string
+  getModalStyle: () => string
+  getModalHeaderStyle: () => string
+  getModalButtonStyle: () => string
+  getModalBackdropStyle: () => string
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
@@ -104,6 +108,28 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     return theme === 'neumorphism' ? 'text-gray-600' : 'text-gray-600'
   }
 
+  const getModalStyle = () => {
+    return theme === 'neumorphism'
+      ? 'neumorphism-modal rounded-lg'
+      : 'bg-white rounded-lg'
+  }
+
+  const getModalHeaderStyle = () => {
+    return theme === 'neumorphism'
+      ? 'neumorphism-modal-header p-4'
+      : 'p-4 border-b border-gray-200'
+  }
+
+  const getModalButtonStyle = () => {
+    return theme === 'neumorphism'
+      ? 'neumorphism-modal-button p-2 rounded'
+      : 'p-2 hover:bg-gray-100 rounded'
+  }
+
+  const getModalBackdropStyle = () => {
+    return 'fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4'
+  }
+
   const value: ThemeContextType = {
     theme,
     setTheme: handleThemeChange,
@@ -117,6 +143,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     getInputStyle,
     getTextColor,
     getSubtextColor,
+    getModalStyle,
+    getModalHeaderStyle,
+    getModalButtonStyle,
+    getModalBackdropStyle,
   }
 
   return (


### PR DESCRIPTION
Refactor Neumorphism design to use white backgrounds with shadow-based depth and apply it consistently across all UI elements.

The previous Neumorphism implementation utilized gray backgrounds, which the user found visually unappealing. This update transitions the design to maintain a white background, achieving concave/convex effects solely through shadows, and ensures this new aesthetic is uniformly applied to all relevant components, including modals, input fields, and card elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-39cde1e5-5e9e-456c-ab29-4038416b3a9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39cde1e5-5e9e-456c-ab29-4038416b3a9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>